### PR TITLE
add runner tags so that jobs pick the right runner

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   build:
     name: Build .NET
-    runs-on: [self-hosted, windows, x64]
+    runs-on: [self-hosted, windows, x64, pella, msbuild]
     steps:
       - uses: actions/checkout@v2
       - name: Setup .NET

--- a/.github/workflows/build-net-framework.yml
+++ b/.github/workflows/build-net-framework.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   build:
     name: Build .NET Framework
-    runs-on: [self-hosted, windows, x64]
+    runs-on: [self-hosted, windows, x64, pella, msbuild]
     steps:
       - uses: actions/checkout@v2
         name: Checkout Code

--- a/.github/workflows/dotnet-nuget-ci-cd.yml
+++ b/.github/workflows/dotnet-nuget-ci-cd.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   build:
     name: Build/Test/Publish
-    runs-on: [self-hosted, windows, x64]
+    runs-on: [self-hosted, windows, x64, pella, msbuild]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/net-framework-nuget-ci-cd.yml
+++ b/.github/workflows/net-framework-nuget-ci-cd.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   build:
     name: Build/Test/Publish
-    runs-on: [self-hosted, windows, x64]
+    runs-on: [self-hosted, windows, x64, pella, msbuild]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Can we retag this as v5 as well?  Currently workflow randomly run on the engineering matlab runners and fail.