### PR TITLE
Adds `upload-artifact-name` as optional parameter for build workflows 👋

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -21,6 +21,10 @@ on:
         required: false
         type: boolean
         default: false
+      upload-artifact-name:
+        required: false
+        type: string
+        default: publish-package
     secrets:
       github-token:
         required: true
@@ -66,6 +70,6 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: publish-package
+          name: "${{ inputs.upload-artifact-name }}"
           path: "${{ inputs.publish-path }}"
         if: ${{ success() && inputs.upload-artifact }}

--- a/.github/workflows/build-net-framework.yml
+++ b/.github/workflows/build-net-framework.yml
@@ -24,6 +24,10 @@ on:
         required: false
         type: boolean
         default: false
+      upload-artifact-name:
+        required: false
+        type: string
+        default: publish-package
     secrets:
       github-token:
         required: true
@@ -70,6 +74,6 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: publish-package
+          name: "${{ inputs.upload-artifact-name }}"
           path: "${{ inputs.publish-path }}"
         if: ${{ success() && inputs.upload-artifact }}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ jobs:
       build-configuration: Debug
       dotnet-version: 6.0.x
       upload-artifact: true
+      upload-artifact-name: artifact-name
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN}}
 ```
@@ -46,6 +47,10 @@ The version of the dotnet SDK to use when building the project.
 
 A boolean value indicating whether to upload the build artifact to GitHub.
 
+##### upload-artifact-name
+
+A name given for the artifact output for the build. Default is `publish-package`
+
 ##### github-token
 
 The GitHub Actions token to use to authenticate to the Vermeer GitHub Packages NuGet repository. This should always be set to `${{ secrets.GITHUB_TOKEN}}` in the calling workflow as shown above.
@@ -69,6 +74,7 @@ jobs:
       msbuild-args: /t:Package /t:TransformWebConfig /p:ExcludeXmlAssemblyFiles=false /p:AutoParameterizationWebConfigConnectionStrings=False
       test-file-glob: "**/*.Test.dll"
       upload-artifact: true
+      upload-artifact-name: artifact-name
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN}}
 ```
@@ -98,6 +104,10 @@ A glob pattern to match compiled MSTest DLL assemblies to run unit tests. If the
 ##### upload-artifact
 
 A boolean value indicating whether to upload the build artifact to GitHub.
+
+##### upload-artifact-name
+
+A name given for the artifact output for the build. Default is `publish-package`
 
 ##### github-token
 


### PR DESCRIPTION
## What:
- Adds additional input parameter for `build-dotnet.yml` and `build-net-framework.yml`.

## Why:
- Additional workflows allow for input for a publish package name. This name is not obvious currently and consumers are required to find the name in the code. This provides an obvious value or a custom value for future consumers
- Allows for parallel builds because there can be multiple artifact outputs

## Impact:
- No impact to current users

![Hello](https://media.giphy.com/media/eYh8R3e43j3cY0slgB/giphy.gif)