### PR TITLE
add working directory input to dotnet-nuget-ci-cd.yml

### DIFF
--- a/.github/workflows/dotnet-nuget-ci-cd.yml
+++ b/.github/workflows/dotnet-nuget-ci-cd.yml
@@ -11,6 +11,10 @@ on:
         required: false
         type: boolean
         default: false
+      working-directory:
+        required: false
+        type: string
+        default: './'
     secrets:
       github-token:
         required: true
@@ -19,6 +23,9 @@ jobs:
   build:
     name: Build/Test/Publish
     runs-on: [self-hosted, windows, x64, pella, msbuild]
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Add working directory input to dotnet-nuget-ci-cd.yml to allow building nuget packages not in the root directory.